### PR TITLE
feat: Add auto-instrumentation support in AWS V1 SDK for Step Functio…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
@@ -29,5 +29,20 @@ final class AwsExperimentalAttributes {
       stringKey("gen_ai.request.model");
   static final AttributeKey<String> AWS_BEDROCK_SYSTEM = stringKey("gen_ai.system");
 
+  static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
+      stringKey("aws.stepfunctions.state_machine.arn");
+
+  static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
+      stringKey("aws.stepfunctions.activity.arn");
+
+  static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
+
+  static final AttributeKey<String> AWS_SECRET_ARN = stringKey("aws.secretsmanager.secret.arn");
+
+  static final AttributeKey<String> AWS_LAMBDA_NAME = stringKey("aws.lambda.function.name");
+
+  static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
+      stringKey("aws.lambda.resource_mapping.id");
+
   private AwsExperimentalAttributes() {}
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
@@ -13,9 +13,15 @@ import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttri
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_ENDPOINT;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_KNOWLEDGE_BASE_ID;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_RESOURCE_ID;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_URL;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_REQUEST_ID;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_SECRET_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_TABLE_NAME;
 
@@ -50,6 +56,18 @@ class AwsSdkExperimentalAttributesExtractor
     setAttribute(attributes, AWS_QUEUE_NAME, originalRequest, RequestAccess::getQueueName);
     setAttribute(attributes, AWS_STREAM_NAME, originalRequest, RequestAccess::getStreamName);
     setAttribute(attributes, AWS_TABLE_NAME, originalRequest, RequestAccess::getTableName);
+    setAttribute(
+        attributes, AWS_STATE_MACHINE_ARN, originalRequest, RequestAccess::getStateMachineArn);
+    setAttribute(
+        attributes,
+        AWS_STEP_FUNCTIONS_ACTIVITY_ARN,
+        originalRequest,
+        RequestAccess::getStepFunctionsActivityArn);
+    setAttribute(attributes, AWS_SNS_TOPIC_ARN, originalRequest, RequestAccess::getSnsTopicArn);
+    setAttribute(attributes, AWS_SECRET_ARN, originalRequest, RequestAccess::getSecretArn);
+    setAttribute(attributes, AWS_LAMBDA_NAME, originalRequest, RequestAccess::getLambdaName);
+    setAttribute(
+        attributes, AWS_LAMBDA_RESOURCE_ID, originalRequest, RequestAccess::getLambdaResourceId);
 
     // Get serviceName defined in the AWS Java SDK V1 Request class.
     String serviceName = request.getServiceName();
@@ -68,6 +86,14 @@ class AwsSdkExperimentalAttributesExtractor
       @Nullable Throwable error) {
     if (response != null) {
       Object awsResp = response.getAwsResponse();
+      setAttribute(attributes, AWS_STATE_MACHINE_ARN, awsResp, RequestAccess::getStateMachineArn);
+      setAttribute(
+          attributes,
+          AWS_STEP_FUNCTIONS_ACTIVITY_ARN,
+          awsResp,
+          RequestAccess::getStepFunctionsActivityArn);
+      setAttribute(attributes, AWS_SNS_TOPIC_ARN, awsResp, RequestAccess::getSnsTopicArn);
+      setAttribute(attributes, AWS_SECRET_ARN, awsResp, RequestAccess::getSecretArn);
       if (awsResp instanceof AmazonWebServiceResponse) {
         AmazonWebServiceResponse<?> awsWebServiceResponse = (AmazonWebServiceResponse<?>) awsResp;
         String requestId = awsWebServiceResponse.getRequestId();

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
@@ -21,6 +21,42 @@ final class RequestAccess {
       };
 
   @Nullable
+  static String getLambdaName(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getLambdaName, request);
+  }
+
+  @Nullable
+  static String getLambdaResourceId(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getLambdaResourceId, request);
+  }
+
+  @Nullable
+  static String getSecretArn(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getSecretArn, request);
+  }
+
+  @Nullable
+  static String getSnsTopicArn(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getSnsTopicArn, request);
+  }
+
+  @Nullable
+  static String getStepFunctionsActivityArn(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getStepFunctionsActivityArn, request);
+  }
+
+  @Nullable
+  static String getStateMachineArn(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getStateMachineArn, request);
+  }
+
+  @Nullable
   static String getBucketName(Object request) {
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
     return invokeOrNull(access.getBucketName, request);
@@ -102,6 +138,12 @@ final class RequestAccess {
   @Nullable private final MethodHandle getDataSourceId;
   @Nullable private final MethodHandle getGuardrailId;
   @Nullable private final MethodHandle getModelId;
+  @Nullable private final MethodHandle getStateMachineArn;
+  @Nullable private final MethodHandle getStepFunctionsActivityArn;
+  @Nullable private final MethodHandle getSnsTopicArn;
+  @Nullable private final MethodHandle getSecretArn;
+  @Nullable private final MethodHandle getLambdaName;
+  @Nullable private final MethodHandle getLambdaResourceId;
 
   private RequestAccess(Class<?> clz) {
     getBucketName = findAccessorOrNull(clz, "getBucketName");
@@ -114,6 +156,12 @@ final class RequestAccess {
     getDataSourceId = findAccessorOrNull(clz, "getDataSourceId");
     getGuardrailId = findAccessorOrNull(clz, "getGuardrailId");
     getModelId = findAccessorOrNull(clz, "getModelId");
+    getStateMachineArn = findAccessorOrNull(clz, "getStateMachineArn");
+    getStepFunctionsActivityArn = findAccessorOrNull(clz, "getActivityArn");
+    getSnsTopicArn = findAccessorOrNull(clz, "getTopicArn");
+    getSecretArn = findAccessorOrNull(clz, "getARN");
+    getLambdaName = findAccessorOrNull(clz, "getFunctionName");
+    getLambdaResourceId = findAccessorOrNull(clz, "getUUID");
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
   compileOnly("com.amazonaws:aws-java-sdk-bedrockagent:1.12.744")
   compileOnly("com.amazonaws:aws-java-sdk-bedrockagentruntime:1.12.744")
   compileOnly("com.amazonaws:aws-java-sdk-bedrockruntime:1.12.744")
+  compileOnly("com.amazonaws:aws-java-sdk-stepfunctions:1.11.+")
+  compileOnly("com.amazonaws:aws-java-sdk-secretsmanager:1.11.+")
+  compileOnly("com.amazonaws:aws-java-sdk-lambda:1.11.+")
 
   // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
   implementation("org.elasticmq:elasticmq-rest-sqs_2.12:1.0.0")


### PR DESCRIPTION
### *Description of changes:*

Changes in upstream package to support new AWS resources in Java V1 SDK.

Related to PR for changes in our ADOT package: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/899

These changes add auto-instrumentation support for the following AWS resources. Additionally, a new attribute for `aws.remote.resource.cfn.primary.identifier` is also added for each new resource.

- Populate `aws.sns.topic.arn` in Span by extracting `TopicArn` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html
  - The CFN Id should be the ARN of the Topic.
- Populate `aws.secretsmanager.secret.arn` in Span by extracting `ARN` from response body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html
  - The CFN Id should be the ARN of the Secret.
- Populate `aws.stepfunctions.state_machine.arn` in Span by extracting `stateMachineArn` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html
  - The CFN Id should be the ARN of the State Machine.
- Populate `aws.stepfunctions.activity.arn` in Span by extracting `activityArn` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html
  - The CFN Id should be the ARN of the Activity.
- Populate `aws.lambda.function.name` in Span by extracting `FunctionName` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
  - The CFN Id should be the ARN of the Lambda Function.
- Populate `aws.lambda.resource_mapping.id` in Span by extracting `UUID` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html
  - The CFN Id should be the UUID of the Event Source Mapping.

### *Test Plan:*
Set up a client-server with auto-instrumentation to verify that the correct span data is being generated.

`aws.lambda.function.name`
<img width="1512" alt="lambda-function-name-span-data-verification-v1" src="https://github.com/user-attachments/assets/ecc6780e-546b-4776-a916-16cac97863ec">

`aws.lambda.resource_mapping.id`
<img width="1512" alt="lambda-resource-mapping-id-span-data-verification-v1" src="https://github.com/user-attachments/assets/5059000a-ef5a-4eec-a0d8-e2e63c144ff3">

`aws.secretsmanager.secret.arn`
<img width="1512" alt="secretsmanager-secret-arn-span-data-verification-v1" src="https://github.com/user-attachments/assets/e0cf9fcb-1d99-4ed9-bf33-f9e04c4ad352">

`aws.sns.topic.arn`
<img width="1512" alt="sns-topic-arn-span-data-verification-v1" src="https://github.com/user-attachments/assets/cc000f1f-ded7-4d02-98e6-545583f47e5e">

`aws.stepfunctions.activity.arn`
<img width="1512" alt="stepfunctions-activity-arn-span-data-verification-v1" src="https://github.com/user-attachments/assets/e3ade244-eb1e-4f5c-9878-5c78ee4f2a32">

`aws.stepfunction.state_machine.arn`
<img width="1512" alt="stepfunctions-state-machine-arn-span-data-verification-v1" src="https://github.com/user-attachments/assets/91670d86-a726-472a-8f0f-b156cd68ef63">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
