### PR TITLE
feat: Add auto-instrumentation support for in AWS V2 SDK for SNS, Sec…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+  testLibrary("software.amazon.awssdk:sfn:2.2.0")
+  testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
 
   // last version that does not use json protocol
   latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:ses:2.2.0")
   testLibrary("software.amazon.awssdk:sfn:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
+  testLibrary("software.amazon.awssdk:lambda:2.2.0")
 
   // last version that does not use json protocol
   latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:sfn:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
+  testLibrary("software.amazon.awssdk:lambda:2.2.0")
 
   // last version that does not use json protocol
   latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
+  testLibrary("software.amazon.awssdk:sfn:2.2.0")
+  testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
 
   // last version that does not use json protocol
   latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+  testLibrary("software.amazon.awssdk:sfn:2.2.0")
+  testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
 
   // last version that does not use json protocol
   latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:ses:2.2.0")
   testLibrary("software.amazon.awssdk:sfn:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
+  testLibrary("software.amazon.awssdk:lambda:2.2.0")
 
   // last version that does not use json protocol
   latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
@@ -25,5 +25,22 @@ final class AwsExperimentalAttributes {
   static final AttributeKey<String> GEN_AI_MODEL = stringKey("gen_ai.request.model");
   static final AttributeKey<String> GEN_AI_SYSTEM = stringKey("gen_ai.system");
 
+  static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
+      stringKey("aws.stepfunctions.state_machine.arn");
+
+  static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
+      stringKey("aws.stepfunctions.activity.arn");
+
+  static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
+
+  static final AttributeKey<String> AWS_SECRET_ARN = stringKey("aws.secretsmanager.secret.arn");
+
+  static final AttributeKey<String> AWS_LAMBDA_NAME = stringKey("aws.lambda.function.name");
+
+  static final AttributeKey<String> AWS_LAMBDA_ARN = stringKey("aws.lambda.function.arn");
+
+  static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
+      stringKey("aws.lambda.resource_mapping.id");
+
   private AwsExperimentalAttributes() {}
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequest.java
@@ -12,8 +12,12 @@ import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BED
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCKRUNTIME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.DYNAMODB;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.KINESIS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.LAMBDA;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.S3;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.SECRETSMANAGER;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.SNS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.SQS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.STEPFUNCTION;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.request;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.response;
 
@@ -76,6 +80,10 @@ enum AwsSdkRequest {
   BedrockListDataSourcesRequest(BEDROCKKNOWLEDGEBASEOPERATION, "ListDataSourcesRequest"),
   BedrockUpdateAgentKnowledgeBaseRequest(
       BEDROCKKNOWLEDGEBASEOPERATION, "UpdateAgentKnowledgeBaseRequest"),
+  SfnRequest(STEPFUNCTION, "SfnRequest"),
+  SnsRequest(SNS, "SnsRequest"),
+  SecretsManagerRequest(SECRETSMANAGER, "SecretsManagerRequest"),
+  LambdaRequest(LAMBDA, "LambdaRequest"),
   // specific requests
   BatchGetItem(
       DYNAMODB,

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -10,8 +10,15 @@ import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttrib
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_DATA_SOURCE_ID;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_KNOWLEDGE_BASE_ID;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_LAMBDA_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_LAMBDA_RESOURCE_ID;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_QUEUE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_QUEUE_URL;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_SECRET_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_TABLE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_MODEL;
@@ -36,7 +43,16 @@ enum AwsSdkRequestType {
   BEDROCKKNOWLEDGEBASEOPERATION(
       request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),
       response(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId")),
-  BEDROCKRUNTIME(request(GEN_AI_MODEL.getKey(), "modelId"));
+  BEDROCKRUNTIME(request(GEN_AI_MODEL.getKey(), "modelId")),
+  STEPFUNCTION(
+      request(AWS_STATE_MACHINE_ARN.getKey(), "stateMachineArn"),
+      request(AWS_STEP_FUNCTIONS_ACTIVITY_ARN.getKey(), "activityArn")),
+  SNS(request(AWS_SNS_TOPIC_ARN.getKey(), "TopicArn")),
+  SECRETSMANAGER(response(AWS_SECRET_ARN.getKey(), "ARN")),
+  LAMBDA(
+      request(AWS_LAMBDA_NAME.getKey(), "FunctionName"),
+      request(AWS_LAMBDA_RESOURCE_ID.getKey(), "UUID"),
+      response(AWS_LAMBDA_ARN.getKey(), "Configuration.FunctionArn"));
 
   // Wrapping in unmodifiableMap
   @SuppressWarnings("ImmutableEnumChecker")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   compileOnly("software.amazon.awssdk:sqs:2.2.0")
   compileOnly("software.amazon.awssdk:sns:2.2.0")
   compileOnly("software.amazon.awssdk:ses:2.2.0")
+  compileOnly("software.amazon.awssdk:sfn:2.2.0")
 
   // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
   implementation("org.elasticmq:elasticmq-rest-sqs_2.12:1.0.0")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
   compileOnly("software.amazon.awssdk:sns:2.2.0")
   compileOnly("software.amazon.awssdk:ses:2.2.0")
   compileOnly("software.amazon.awssdk:sfn:2.2.0")
+  compileOnly("software.amazon.awssdk:lambda:2.2.0")
+  compileOnly("software.amazon.awssdk:secretsmanager:2.2.0")
 
   // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
   implementation("org.elasticmq:elasticmq-rest-sqs_2.12:1.0.0")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -33,6 +33,9 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sfn.model.DescribeStateMachineRequest
+import software.amazon.awssdk.services.sfn.model.DescribeActivityRequest
 import spock.lang.Unroll
 
 import java.time.Duration
@@ -131,6 +134,10 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
             } else if (service == "BedrockRuntime" && operation == "InvokeModel") {
               "gen_ai.request.model" "meta.llama2-13b-chat-v1"
               "gen_ai.system" "aws_bedrock"
+            } else if (service == "Sfn" && operation == "DescribeStateMachine") {
+              "aws.stepfunctions.state_machine.arn" "stateMachineArn"
+            } else if (service == "Sfn" && operation == "DescribeActivity") {
+              "aws.stepfunctions.activity.arn" "activityArn"
             }
 
           }
@@ -174,6 +181,12 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
           <ResponseMetadata><RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId></ResponseMetadata>
         </DeleteOptionGroupResponse>
         """
+    "Sfn" | "DescribeStateMachine" | "POST" | "UNKNOWN" | SfnClient.builder()
+    | { c -> c.describeStateMachine(DescribeStateMachineRequest.builder().stateMachineArn("stateMachineArn").build()) }
+    | ""
+    "Sfn" | "DescribeActivity" | "POST" | "UNKNOWN" | SfnClient.builder()
+    | { c -> c.describeActivity(DescribeActivityRequest.builder().activityArn("activityArn").build()) }
+    | ""
   }
 
   def "send #operation async request with builder #builder.class.getName() mocked response"() {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -38,11 +38,11 @@ import software.amazon.awssdk.services.sfn.model.DescribeStateMachineRequest
 import software.amazon.awssdk.services.sfn.model.DescribeActivityRequest
 import software.amazon.awssdk.services.lambda.LambdaClient
 import software.amazon.awssdk.services.lambda.model.GetFunctionRequest
-import software.amazon.awssdk.services.lambda.model.GetEventSourceMappingRequest;
-import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.awssdk.services.sns.model.PublishRequest;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.lambda.model.GetEventSourceMappingRequest
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
 import spock.lang.Unroll
 
 


### PR DESCRIPTION
### *Description of changes:*

Changes in upstream package to support new AWS resources in Java V2 SDK.

Mostly duplicating implementation changes from this PR since they are not merged yet and I had to test locally: https://github.com/mxiamxia/opentelemetry-java-instrumentation/pull/10

These changes add auto-instrumentation support for the following AWS resources. Additionally, a new attribute for `aws.remote.resource.cfn.primary.identifier` is also added for each new resource.

- Populate `aws.sns.topic.arn` in Span by extracting `TopicArn` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html
  - The CFN Id should be the ARN of the Topic.
- Populate `aws.secretsmanager.secret.arn` in Span by extracting `ARN` from response body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html
  - The CFN Id should be the ARN of the Secret.
- Populate `aws.stepfunctions.state_machine.arn` in Span by extracting `stateMachineArn` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html
  - The CFN Id should be the ARN of the State Machine.
- Populate `aws.stepfunctions.activity.arn` in Span by extracting `activityArn` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-activity.html
  - The CFN Id should be the ARN of the Activity.
- Populate `aws.lambda.function.name` in Span by extracting `FunctionName` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
  - The CFN Id should be the ARN of the Lambda Function.
- Populate `aws.lambda.resource_mapping.id` in Span by extracting `UUID` from the request body.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html
  - The CFN Id should be the UUID of the Event Source Mapping.

### *Test Plan:*
Set up a client-server with auto-instrumentation to verify that the correct span data is being generated.

`aws.lambda.function.name`
<img width="1512" alt="lambda-function-name-span-data-verification-v2" src="https://github.com/user-attachments/assets/a46a46e3-fdbc-484a-b9be-64a8578f0c5c">

`aws.lambda.resource_mapping.id`
<img width="1512" alt="lambda-resource-mapping-id-span-data-verification-v2" src="https://github.com/user-attachments/assets/ae0b09aa-7aa4-4ce0-a7c5-8cd2fc54e3cd">


`aws.secretsmanager.secret.arn`
<img width="1512" alt="secretsmanager-secret-arn-span-data-verification-v2" src="https://github.com/user-attachments/assets/02fd6fab-f6bb-4184-9b90-5e963ed6a90d">


`aws.sns.topic.arn`
<img width="1512" alt="sns-topic-arn-span-data-verification-v2" src="https://github.com/user-attachments/assets/92084578-7640-4423-b9af-6ce103be0fbe">


`aws.stepfunctions.activity.arn`
<img width="1512" alt="sfn-activity-arn-span-data-verification-v2" src="https://github.com/user-attachments/assets/19d035d3-ee98-40b4-81d8-1c235326ba6a">


`aws.stepfunction.state_machine.arn`
<img width="1512" alt="sfn-state-machine-arn-span-data-verification-v2" src="https://github.com/user-attachments/assets/9338cecb-9059-41e8-b902-916a741c0da4">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
