### PR TITLE
feat: update bedrock resource attributes

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
@@ -23,6 +23,7 @@ final class AwsExperimentalAttributes {
       stringKey("aws.bedrock.knowledge_base.id");
   static final AttributeKey<String> AWS_DATA_SOURCE_ID = stringKey("aws.bedrock.data_source.id");
   static final AttributeKey<String> AWS_GUARDRAIL_ID = stringKey("aws.bedrock.guardrail.id");
+  static final AttributeKey<String> AWS_GUARDRAIL_ARN = stringKey("aws.bedrock.guardrail.arn");
 
   // TODO: Merge in gen_ai attributes in opentelemetry-semconv-incubating once upgrade to v1.26.0
   static final AttributeKey<String> AWS_BEDROCK_RUNTIME_MODEL_ID =

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttri
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BEDROCK_SYSTEM;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BUCKET_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_ENDPOINT;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_GUARDRAIL_ARN;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_KNOWLEDGE_BASE_ID;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
@@ -154,6 +155,7 @@ class AwsSdkExperimentalAttributesExtractor
     switch (serviceName) {
       case BEDROCK_SERVICE:
         setAttribute(attributes, AWS_GUARDRAIL_ID, awsResp, RequestAccess::getGuardrailId);
+        setAttribute(attributes, AWS_GUARDRAIL_ARN, awsResp, RequestAccess::getGuardrailArn);
         break;
       case BEDROCK_AGENT_SERVICE:
         String responseClassName = awsResp.getClass().getSimpleName();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
@@ -16,6 +16,7 @@ final class AwsExperimentalAttributes {
   static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
   static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
   static final AttributeKey<String> AWS_GUARDRAIL_ID = stringKey("aws.bedrock.guardrail.id");
+  static final AttributeKey<String> AWS_GUARDRAIL_ARN = stringKey("aws.bedrock.guardrail.arn");
   static final AttributeKey<String> AWS_AGENT_ID = stringKey("aws.bedrock.agent.id");
   static final AttributeKey<String> AWS_DATA_SOURCE_ID = stringKey("aws.bedrock.data_source.id");
   static final AttributeKey<String> AWS_KNOWLEDGE_BASE_ID =

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCK;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCKAGENTOPERATION;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCKAGENTRUNTIMEOPERATION;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCKDATASOURCEOPERATION;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCKKNOWLEDGEBASEOPERATION;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkRequestType.BEDROCKRUNTIME;
@@ -42,7 +43,7 @@ enum AwsSdkRequest {
   SqsRequest(SQS, "SqsRequest"),
   KinesisRequest(KINESIS, "KinesisRequest"),
   BedrockRequest(BEDROCK, "BedrockRequest"),
-  BedrockAgentRuntimeRequest(BEDROCKAGENTOPERATION, "BedrockAgentRuntimeRequest"),
+  BedrockAgentRuntimeRequest(BEDROCKAGENTRUNTIMEOPERATION, "BedrockAgentRuntimeRequest"),
   BedrockRuntimeRequest(BEDROCKRUNTIME, "BedrockRuntimeRequest"),
   // BedrockAgent API based requests. We only support operations that are related to
   // Agent/DataSources/KnowledgeBases

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -39,6 +39,8 @@ enum AwsSdkRequestType {
       request(AWS_GUARDRAIL_ID.getKey(), "guardrailIdentifier"),
       response(AWS_GUARDRAIL_ARN.getKey(), "guardrailArn")),
   BEDROCKAGENTOPERATION(
+      request(AWS_AGENT_ID.getKey(), "agentId"), response(AWS_AGENT_ID.getKey(), "agentId")),
+  BEDROCKAGENTRUNTIMEOPERATION(
       request(AWS_AGENT_ID.getKey(), "agentId"),
       response(AWS_AGENT_ID.getKey(), "agentId"),
       request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_AGENT_ID;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_BUCKET_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_DATA_SOURCE_ID;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ARN;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_KNOWLEDGE_BASE_ID;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_LAMBDA_ARN;
@@ -34,9 +35,14 @@ enum AwsSdkRequestType {
   SQS(request(AWS_QUEUE_URL.getKey(), "QueueUrl"), request(AWS_QUEUE_NAME.getKey(), "QueueName")),
   KINESIS(request(AWS_STREAM_NAME.getKey(), "StreamName")),
   DYNAMODB(request(AWS_TABLE_NAME.getKey(), "TableName")),
-  BEDROCK(request(AWS_GUARDRAIL_ID.getKey(), "guardrailIdentifier")),
+  BEDROCK(
+      request(AWS_GUARDRAIL_ID.getKey(), "guardrailIdentifier"),
+      response(AWS_GUARDRAIL_ARN.getKey(), "guardrailArn")),
   BEDROCKAGENTOPERATION(
-      request(AWS_AGENT_ID.getKey(), "agentId"), response(AWS_AGENT_ID.getKey(), "agentId")),
+      request(AWS_AGENT_ID.getKey(), "agentId"),
+      response(AWS_AGENT_ID.getKey(), "agentId"),
+      request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),
+      response(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId")),
   BEDROCKDATASOURCEOPERATION(
       request(AWS_DATA_SOURCE_ID.getKey(), "dataSourceId"),
       response(AWS_DATA_SOURCE_ID.getKey(), "dataSourceId")),


### PR DESCRIPTION
### *Summary of Changes:*

- Updating the CFN Primary Id for Guardrail to be the ARN.  (Verified this in the AWS Cloudformation Console)

  ![Screenshot 2024-10-09 at 12 44 12 PM](https://github.com/user-attachments/assets/1a7437f1-4269-42f0-b4d9-db9f5f37b3a7)

- Updated `BEDROCKAGENTOPERATION` enum.
  - Our Bedrock Agent Runtime should support both Agent Operation and KnowledgeBased Operation [like in Java SDK v1](https://github.com/mxiamxia/opentelemetry-java-instrumentation/blob/965f7878c79c2be5851f23cf272edd39585f42af/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java#L133).

Related changes in ADOT package: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/905

### *Testing Plan:*

Set up sample apps and manually verified correct span attributes were generated via auto-instrumentation. 

`Java SDK v1`
![bedrock-guardrail-span-data-verification-v1](https://github.com/user-attachments/assets/70b2c126-cf73-4a70-b63f-e4cd78101604)

`Java SDK v2`
![bedrock-guardrail-span-data-verification-v2](https://github.com/user-attachments/assets/d4857400-3f78-4e5d-aa1a-bb0d26b6213e)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.