### PR TITLE
feat: set up gen ai inference attributes for foundational text models for v2 sdk

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -5,6 +5,13 @@ plugins {
 dependencies {
   implementation("io.opentelemetry.contrib:opentelemetry-aws-xray-propagator")
 
+  val jsonVersion = "20240303"
+  implementation("org.json:json") {
+    version {
+      strictly(jsonVersion)
+    }
+  }
+
   library("software.amazon.awssdk:aws-core:2.2.0")
   library("software.amazon.awssdk:sqs:2.2.0")
   library("software.amazon.awssdk:sns:2.2.0")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
@@ -25,6 +25,17 @@ final class AwsExperimentalAttributes {
   // TODO: Merge in gen_ai attributes in opentelemetry-semconv-incubating once upgrade to v1.26.0
   static final AttributeKey<String> GEN_AI_MODEL = stringKey("gen_ai.request.model");
   static final AttributeKey<String> GEN_AI_SYSTEM = stringKey("gen_ai.system");
+  static final AttributeKey<String> GEN_AI_REQUEST_MAX_TOKENS =
+      stringKey("gen_ai.request.max_tokens");
+  static final AttributeKey<String> GEN_AI_REQUEST_TEMPERATURE =
+      stringKey("gen_ai.request.temperature");
+  static final AttributeKey<String> GEN_AI_REQUEST_TOP_P = stringKey("gen_ai.request.top_p");
+  static final AttributeKey<String> GEN_AI_RESPONSE_FINISH_REASONS =
+      stringKey("gen_ai.response.finish_reasons");
+  static final AttributeKey<String> GEN_AI_USAGE_INPUT_TOKENS =
+      stringKey("gen_ai.usage.input_tokens");
+  static final AttributeKey<String> GEN_AI_USAGE_OUTPUT_TOKENS =
+      stringKey("gen_ai.usage.output_tokens");
 
   static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
       stringKey("aws.stepfunctions.state_machine.arn");
@@ -44,4 +55,13 @@ final class AwsExperimentalAttributes {
       stringKey("aws.lambda.resource_mapping.id");
 
   private AwsExperimentalAttributes() {}
+
+  static boolean isGenAiInferenceAttribute(String attributeKey) {
+    return attributeKey.equals(GEN_AI_REQUEST_TEMPERATURE.getKey())
+        || attributeKey.equals(GEN_AI_REQUEST_MAX_TOKENS.getKey())
+        || attributeKey.equals(GEN_AI_REQUEST_TOP_P.getKey())
+        || attributeKey.equals(GEN_AI_RESPONSE_FINISH_REASONS.getKey())
+        || attributeKey.equals(GEN_AI_USAGE_INPUT_TOKENS.getKey())
+        || attributeKey.equals(GEN_AI_USAGE_OUTPUT_TOKENS.getKey());
+  }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -23,6 +23,12 @@ import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttrib
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_TABLE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_MODEL;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TEMPERATURE;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TOP_P;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_USAGE_INPUT_TOKENS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.request;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.response;
 
@@ -51,7 +57,15 @@ enum AwsSdkRequestType {
   BEDROCKKNOWLEDGEBASEOPERATION(
       request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),
       response(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId")),
-  BEDROCKRUNTIME(request(GEN_AI_MODEL.getKey(), "modelId")),
+  BEDROCKRUNTIME(
+      request(GEN_AI_MODEL.getKey(), "modelId"),
+      request(GEN_AI_REQUEST_TEMPERATURE.getKey(), "body"),
+      request(GEN_AI_REQUEST_MAX_TOKENS.getKey(), "body"),
+      request(GEN_AI_REQUEST_TOP_P.getKey(), "body"),
+      request(GEN_AI_USAGE_INPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_USAGE_INPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_USAGE_OUTPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_RESPONSE_FINISH_REASONS.getKey(), "body")),
   STEPFUNCTION(
       request(AWS_STATE_MACHINE_ARN.getKey(), "stateMachineArn"),
       request(AWS_STEP_FUNCTIONS_ACTIVITY_ARN.getKey(), "activityArn")),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
@@ -109,8 +109,14 @@ class Serializer {
   private static Double getTemperature(JSONObject body) {
     // NOTE: There is no way to get the model id information without a large-effort refactor. As a
     // workaround we try every possible path and take whichever value is not null (there will only
-    // ever
-    // exist one non-null value at a time).
+    // ever exist one non-null value at a time).
+    // Model -> Path Mapping:
+    // Amazon Titan -> "/textGenerationConfig/temperature"
+    // Anthropic Claude -> "/temperature"
+    // Cohere Command -> "/temperature"
+    // AI21 Jamba -> "/temperature"
+    // Meta Llama -> "/temperature"
+    // Mistral AI -> "/temperature"
     return Stream.of("/textGenerationConfig/temperature", "/temperature")
         .map(
             path -> {
@@ -127,11 +133,14 @@ class Serializer {
   }
 
   private static Integer getMaxTokens(JSONObject body) {
-    return Stream.of(
-            "/textGenerationConfig/maxTokenCount",
-            "/max_tokens",
-            "/max_tokens_to_sample",
-            "/max_gen_len")
+    // Model -> Path Mapping:
+    // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
+    // Anthropic Claude -> "/max_tokens"
+    // Cohere Command -> "/max_tokens"
+    // AI21 Jamba -> "/max_tokens"
+    // Meta Llama -> "/max_gen_len"
+    // Mistral AI -> "/max_tokens"
+    return Stream.of("/textGenerationConfig/maxTokenCount", "/max_tokens", "/max_gen_len")
         .map(
             path -> {
               try {
@@ -147,6 +156,13 @@ class Serializer {
   }
 
   private static Double getTopP(JSONObject body) {
+    // Model -> Path Mapping:
+    // Amazon Titan -> "/textGenerationConfig/topP"
+    // Anthropic Claude -> "/top_p"
+    // Cohere Command -> "/p"
+    // AI21 Jamba -> "/top_p"
+    // Meta Llama -> "/top_p"
+    // Mistral AI -> "/top_p"
     return Stream.of("/textGenerationConfig/topP", "/top_p", "/p")
         .map(
             path -> {
@@ -163,6 +179,13 @@ class Serializer {
   }
 
   private static Integer getInputTokens(JSONObject body) {
+    // Model -> Path Mapping:
+    // Amazon Titan -> "/inputTextTokenCount"
+    // Anthropic Claude -> "/usage/input_tokens"
+    // Cohere Command -> "/prompt"
+    // AI21 Jamba -> "/usage/prompt_tokens"
+    // Meta Llama -> "/prompt_token_count"
+    // Mistral AI -> "/prompt"
     Integer directTokenCount =
         Stream.of(
                 "/inputTextTokenCount",
@@ -206,6 +229,13 @@ class Serializer {
   }
 
   private static Integer getOutputTokens(JSONObject body) {
+    // Model -> Path Mapping:
+    // Amazon Titan -> "/results/0/tokenCount"
+    // Anthropic Claude -> "/usage/output_tokens"
+    // Cohere Command -> "/generations/0/text"
+    // AI21 Jamba -> "/usage/completion_tokens"
+    // Meta Llama -> "/generation_token_count"
+    // Mistral AI -> "/outputs/0/text"
     Integer directTokenCount =
         Stream.of(
                 "/results/0/tokenCount",
@@ -249,6 +279,13 @@ class Serializer {
   }
 
   private static String getFinishReasons(JSONObject body) {
+    // Model -> Path Mapping:
+    // Amazon Titan -> "/results/0/completionReason"
+    // Anthropic Claude -> "/stop_reason"
+    // Cohere Command -> "/generations/0/finish_reason"
+    // AI21 Jamba -> "/choices/0/finish_reason"
+    // Meta Llama -> "/stop_reason"
+    // Mistral AI -> "/outputs/0/stop_reason"
     return Stream.of(
             "/results/0/completionReason",
             "/stop_reason",

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
@@ -114,6 +114,7 @@ class Serializer {
     // Amazon Titan -> "/textGenerationConfig/temperature"
     // Anthropic Claude -> "/temperature"
     // Cohere Command -> "/temperature"
+    // Cohere Command R -> "/temperature"
     // AI21 Jamba -> "/temperature"
     // Meta Llama -> "/temperature"
     // Mistral AI -> "/temperature"
@@ -137,6 +138,7 @@ class Serializer {
     // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
     // Anthropic Claude -> "/max_tokens"
     // Cohere Command -> "/max_tokens"
+    // Cohere Command R -> "/max_tokens"
     // AI21 Jamba -> "/max_tokens"
     // Meta Llama -> "/max_gen_len"
     // Mistral AI -> "/max_tokens"
@@ -160,6 +162,7 @@ class Serializer {
     // Amazon Titan -> "/textGenerationConfig/topP"
     // Anthropic Claude -> "/top_p"
     // Cohere Command -> "/p"
+    // Cohere Command R -> "/p"
     // AI21 Jamba -> "/top_p"
     // Meta Llama -> "/top_p"
     // Mistral AI -> "/top_p"
@@ -183,6 +186,7 @@ class Serializer {
     // Amazon Titan -> "/inputTextTokenCount"
     // Anthropic Claude -> "/usage/input_tokens"
     // Cohere Command -> "/prompt"
+    // Cohere Command R -> "/message"
     // AI21 Jamba -> "/usage/prompt_tokens"
     // Meta Llama -> "/prompt_token_count"
     // Mistral AI -> "/prompt"
@@ -209,7 +213,7 @@ class Serializer {
       return directTokenCount;
     }
 
-    return Stream.of("/prompt")
+    return Stream.of("/prompt", "/message")
         .map(
             path -> {
               try {
@@ -233,6 +237,7 @@ class Serializer {
     // Amazon Titan -> "/results/0/tokenCount"
     // Anthropic Claude -> "/usage/output_tokens"
     // Cohere Command -> "/generations/0/text"
+    // Cohere Command R -> "/text"
     // AI21 Jamba -> "/usage/completion_tokens"
     // Meta Llama -> "/generation_token_count"
     // Mistral AI -> "/outputs/0/text"
@@ -259,7 +264,7 @@ class Serializer {
       return directTokenCount;
     }
 
-    return Stream.of("/generations/0/text", "/outputs/0/text")
+    return Stream.of("/generations/0/text", "/outputs/0/text", "/text")
         .map(
             path -> {
               try {
@@ -283,6 +288,7 @@ class Serializer {
     // Amazon Titan -> "/results/0/completionReason"
     // Anthropic Claude -> "/stop_reason"
     // Cohere Command -> "/generations/0/finish_reason"
+    // Cohere Command R -> "/finish_reason"
     // AI21 Jamba -> "/choices/0/finish_reason"
     // Meta Llama -> "/stop_reason"
     // Mistral AI -> "/outputs/0/stop_reason"
@@ -291,7 +297,8 @@ class Serializer {
             "/stop_reason",
             "/generations/0/finish_reason",
             "/choices/0/finish_reason",
-            "/outputs/0/stop_reason")
+            "/outputs/0/stop_reason",
+            "/finish_reason")
         .map(
             path -> {
               try {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
@@ -9,9 +9,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+import org.json.JSONPointerException;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -37,8 +43,42 @@ class Serializer {
     if (target instanceof Map) {
       return serialize(((Map<?, ?>) target).keySet());
     }
+    if (target instanceof SdkBytes) {
+      return serialize((SdkBytes) target);
+    }
     // simple type
     return target.toString();
+  }
+
+  @Nullable
+  @SuppressWarnings("unchecked")
+  <T> T serialize(String attributeName, Object target, Class<T> returnType) {
+    try {
+      JSONObject jsonBody;
+      if (target instanceof SdkBytes) {
+        jsonBody = new JSONObject(((SdkBytes) target).asUtf8String());
+      } else {
+        return null;
+      }
+      switch (attributeName) {
+        case "gen_ai.request.temperature":
+          return (T) getTemperature(jsonBody);
+        case "gen_ai.request.max_tokens":
+          return (T) getMaxTokens(jsonBody);
+        case "gen_ai.request.top_p":
+          return (T) getTopP(jsonBody);
+        case "gen_ai.usage.input_tokens":
+          return (T) getInputTokens(jsonBody);
+        case "gen_ai.usage.output_tokens":
+          return (T) getOutputTokens(jsonBody);
+        case "gen_ai.response.finish_reasons":
+          return (T) getFinishReasons(jsonBody);
+        default:
+          return null;
+      }
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   @Nullable
@@ -64,5 +104,174 @@ class Serializer {
   private String serialize(Collection<?> collection) {
     String serialized = collection.stream().map(this::serialize).collect(Collectors.joining(","));
     return (StringUtils.isEmpty(serialized) ? null : "[" + serialized + "]");
+  }
+
+  private static Double getTemperature(JSONObject body) {
+    // NOTE: There is no way to get the model id information without a large-effort refactor. As a
+    // workaround we try every possible path and take whichever value is not null (there will only
+    // ever
+    // exist one non-null value at a time).
+    return Stream.of("/textGenerationConfig/temperature", "/temperature")
+        .map(
+            path -> {
+              try {
+                Object val = new JSONPointer(path).queryFrom(body);
+                return val != null ? Double.valueOf(val.toString()) : null;
+              } catch (JSONPointerException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static Integer getMaxTokens(JSONObject body) {
+    return Stream.of(
+            "/textGenerationConfig/maxTokenCount",
+            "/max_tokens",
+            "/max_tokens_to_sample",
+            "/max_gen_len")
+        .map(
+            path -> {
+              try {
+                Object val = new JSONPointer(path).queryFrom(body);
+                return val != null ? Integer.valueOf(val.toString()) : null;
+              } catch (JSONPointerException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static Double getTopP(JSONObject body) {
+    return Stream.of("/textGenerationConfig/topP", "/top_p", "/p")
+        .map(
+            path -> {
+              try {
+                Object val = new JSONPointer(path).queryFrom(body);
+                return val != null ? Double.valueOf(val.toString()) : null;
+              } catch (JSONPointerException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static Integer getInputTokens(JSONObject body) {
+    Integer directTokenCount =
+        Stream.of(
+                "/inputTextTokenCount",
+                "/usage/input_tokens",
+                "/usage/prompt_tokens",
+                "/prompt_token_count")
+            .map(
+                path -> {
+                  try {
+                    Object val = new JSONPointer(path).queryFrom(body);
+                    return val != null ? Integer.valueOf(val.toString()) : null;
+                  } catch (JSONPointerException e) {
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+
+    if (directTokenCount != null) {
+      return directTokenCount;
+    }
+
+    return Stream.of("/prompt")
+        .map(
+            path -> {
+              try {
+                Object val = new JSONPointer(path).queryFrom(body);
+                // NOTE: For some models, the token count is not directly available. In these cases
+                // we approximate the token count with (total_chars / 6). This is recommended by the
+                // Bedrock docs for pricing purposes.
+                // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
+                return val != null ? (int) Math.ceil(val.toString().length() / 6.0) : null;
+              } catch (JSONPointerException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static Integer getOutputTokens(JSONObject body) {
+    Integer directTokenCount =
+        Stream.of(
+                "/results/0/tokenCount",
+                "/usage/output_tokens",
+                "/usage/completion_tokens",
+                "/generation_token_count")
+            .map(
+                path -> {
+                  try {
+                    Object val = new JSONPointer(path).queryFrom(body);
+                    return val != null ? Integer.valueOf(val.toString()) : null;
+                  } catch (JSONPointerException e) {
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+
+    if (directTokenCount != null) {
+      return directTokenCount;
+    }
+
+    return Stream.of("/generations/0/text", "/outputs/0/text")
+        .map(
+            path -> {
+              try {
+                Object val = new JSONPointer(path).queryFrom(body);
+                // NOTE: For some models, the token count is not directly available. In these cases
+                // we approximate the token count with (total_chars / 6). This is recommended by the
+                // Bedrock docs for pricing purposes.
+                // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
+                return val != null ? (int) Math.ceil(val.toString().length() / 6.0) : null;
+              } catch (JSONPointerException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static String getFinishReasons(JSONObject body) {
+    return Stream.of(
+            "/results/0/completionReason",
+            "/stop_reason",
+            "/generations/0/finish_reason",
+            "/choices/0/finish_reason",
+            "/outputs/0/stop_reason")
+        .map(
+            path -> {
+              try {
+                Object val = new JSONPointer(path).queryFrom(body);
+                // NOTE: the Span class defined in upstream Otel core library does not support
+                // String[] attribute
+                // values at the moment. However, String[] is recommended by the Otel Gen AI
+                // semantic
+                // conventions so we assign this string literal which looks like an array for now.
+                // TODO: Change type to String[] once it is supported.
+                return val != null ? ("[" + val.toString() + "]") : null;
+              } catch (JSONPointerException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
   }
 }


### PR DESCRIPTION
*Description of changes:*
Adding auto-instrumentation support for GenAI inference parameters for Java V2 AWS SDK.

The following foundational text models are supported:
- AI21 Jamba
- Amazon Titan
- Anthropic Claude
- Cohere Command
- Cohere Command R
- Meta Llama
- Mistral AI

Full list can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html). Note, we do not support Stability AI models at this time since they are focused on text to image.

New inference parameter attributes added according to OpenTelemetry Semantic Conventions for [GenAI attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#genai-attributes):
- `gen_ai.request.max_tokens`
- `gen_ai.request.temperature`
- `gen_ai.request.top_p`
- `gen_ai.response.finish_reasons`
- `gen_ai.usage.input_tokens`
- `gen_ai.usage.output_tokens`

*Test Plan:*
Set up sample app to make Bedrock Runtime `InvokeModel` API calls to the supported foundational models and verified the auto-instrumentation attributes.

`AI21 Jamba`
<img width="2560" alt="ai21-jamba" src="https://github.com/user-attachments/assets/d737f396-9dad-480c-b0af-25490dda33a2">

`Amazon Titan`
<img width="2560" alt="amazon-titan" src="https://github.com/user-attachments/assets/be2e7eaf-4dfb-417b-a90b-484f3c23e44a">

`Anthropic Claude`
<img width="2560" alt="anthropic-claude" src="https://github.com/user-attachments/assets/458d6e3a-4c64-44cc-aabc-1cba50dcd685">

`Cohere Command`
<img width="2560" alt="cohere-command" src="https://github.com/user-attachments/assets/01f2a418-6f58-4998-9d10-21ac677f1750">

`Cohere Command R`
![cohere-command-r](https://github.com/user-attachments/assets/641324d3-0d33-457a-8218-58987d0abf61)

`Meta Llama`
<img width="2560" alt="meta-llama" src="https://github.com/user-attachments/assets/752f9dd5-d877-4179-8c67-eddecff687d8">

`Mistral AI`
<img width="2560" alt="mistral-ai" src="https://github.com/user-attachments/assets/55f1fff5-5cea-49bc-bcd0-d1f3a15518f2">