### PR TITLE
Set Up LLM Inference Attributes Auto-Instrumentation Java v1

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
@@ -30,6 +30,23 @@ final class AwsExperimentalAttributes {
       stringKey("gen_ai.request.model");
   static final AttributeKey<String> AWS_BEDROCK_SYSTEM = stringKey("gen_ai.system");
 
+  static final AttributeKey<String> GEN_AI_REQUEST_MAX_TOKENS =
+      stringKey("gen_ai.request.max_tokens");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_TEMPERATURE =
+      stringKey("gen_ai.request.temperature");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_TOP_P = stringKey("gen_ai.request.top_p");
+
+  static final AttributeKey<String> GEN_AI_RESPONSE_FINISH_REASONS =
+      stringKey("gen_ai.response.finish_reasons");
+
+  static final AttributeKey<String> GEN_AI_USAGE_INPUT_TOKENS =
+      stringKey("gen_ai.usage.input_tokens");
+
+  static final AttributeKey<String> GEN_AI_USAGE_OUTPUT_TOKENS =
+      stringKey("gen_ai.usage.output_tokens");
+
   static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
       stringKey("aws.stepfunctions.state_machine.arn");
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
@@ -25,6 +25,12 @@ import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttri
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_TABLE_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_REQUEST_TEMPERATURE;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_REQUEST_TOP_P;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_USAGE_INPUT_TOKENS;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
 
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.Request;
@@ -144,6 +150,14 @@ class AwsSdkExperimentalAttributesExtractor
         Function<Object, String> getter = RequestAccess::getModelId;
         String modelId = getter.apply(originalRequest);
         attributes.put(AWS_BEDROCK_RUNTIME_MODEL_ID, modelId);
+
+        setAttribute(
+            attributes, GEN_AI_REQUEST_MAX_TOKENS, originalRequest, RequestAccess::getMaxTokens);
+        setAttribute(
+            attributes, GEN_AI_REQUEST_TEMPERATURE, originalRequest, RequestAccess::getTemperature);
+        setAttribute(attributes, GEN_AI_REQUEST_TOP_P, originalRequest, RequestAccess::getTopP);
+        setAttribute(
+            attributes, GEN_AI_USAGE_INPUT_TOKENS, originalRequest, RequestAccess::getInputTokens);
         break;
       default:
         break;
@@ -172,6 +186,17 @@ class AwsSdkExperimentalAttributesExtractor
       case BEDROCK_AGENT_RUNTIME_SERVICE:
         setAttribute(attributes, AWS_AGENT_ID, awsResp, RequestAccess::getAgentId);
         setAttribute(attributes, AWS_KNOWLEDGE_BASE_ID, awsResp, RequestAccess::getKnowledgeBaseId);
+        break;
+      case BEDROCK_RUNTIME_SERVICE:
+        if (!Objects.equals(awsResp.getClass().getSimpleName(), "InvokeModelResult")) {
+          break;
+        }
+
+        setAttribute(attributes, GEN_AI_USAGE_INPUT_TOKENS, awsResp, RequestAccess::getInputTokens);
+        setAttribute(
+            attributes, GEN_AI_USAGE_OUTPUT_TOKENS, awsResp, RequestAccess::getOutputTokens);
+        setAttribute(
+            attributes, GEN_AI_RESPONSE_FINISH_REASONS, awsResp, RequestAccess::getFinishReasons);
         break;
       default:
         break;

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
@@ -108,23 +108,55 @@ final class RequestAccess {
         .orElse(null);
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
+  // Anthropic Claude -> "/max_tokens"
+  // Cohere Command -> "/max_tokens"
+  // Cohere Command R -> "/max_tokens"
+  // AI21 Jamba -> "/max_tokens"
+  // Meta Llama -> "/max_gen_len"
+  // Mistral AI -> "/max_tokens"
   @Nullable
   static String getMaxTokens(Object target) {
     return findFirstMatchingPath(
         getJsonBody(target), "/textGenerationConfig/maxTokenCount", "/max_tokens", "/max_gen_len");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/textGenerationConfig/temperature"
+  // Anthropic Claude -> "/temperature"
+  // Cohere Command -> "/temperature"
+  // Cohere Command R -> "/temperature"
+  // AI21 Jamba -> "/temperature"
+  // Meta Llama -> "/temperature"
+  // Mistral AI -> "/temperature"
   @Nullable
   static String getTemperature(Object target) {
     return findFirstMatchingPath(
         getJsonBody(target), "/textGenerationConfig/temperature", "/temperature");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/textGenerationConfig/topP"
+  // Anthropic Claude -> "/top_p"
+  // Cohere Command -> "/p"
+  // Cohere Command R -> "/p"
+  // AI21 Jamba -> "/top_p"
+  // Meta Llama -> "/top_p"
+  // Mistral AI -> "/top_p"
   @Nullable
   static String getTopP(Object target) {
     return findFirstMatchingPath(getJsonBody(target), "/textGenerationConfig/topP", "/top_p", "/p");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/inputTextTokenCount"
+  // Anthropic Claude -> "/usage/input_tokens"
+  // Cohere Command -> "/prompt"
+  // Cohere Command R -> "/message"
+  // AI21 Jamba -> "/usage/prompt_tokens"
+  // Meta Llama -> "/prompt_token_count"
+  // Mistral AI -> "/prompt"
   @Nullable
   static String getInputTokens(Object target) {
     JsonNode jsonBody = getJsonBody(target);
@@ -149,6 +181,14 @@ final class RequestAccess {
     return approximateTokenCount(jsonBody, "/prompt", "/message");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/results/0/tokenCount"
+  // Anthropic Claude -> "/usage/output_tokens"
+  // Cohere Command -> "/generations/0/text"
+  // Cohere Command R -> "/text"
+  // AI21 Jamba -> "/usage/completion_tokens"
+  // Meta Llama -> "/generation_token_count"
+  // Mistral AI -> "/outputs/0/text"
   @Nullable
   static String getOutputTokens(Object target) {
     JsonNode jsonBody = getJsonBody(target);
@@ -172,6 +212,14 @@ final class RequestAccess {
     return approximateTokenCount(jsonBody, "/outputs/0/text", "/text");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/results/0/completionReason"
+  // Anthropic Claude -> "/stop_reason"
+  // Cohere Command -> "/generations/0/finish_reason"
+  // Cohere Command R -> "/finish_reason"
+  // AI21 Jamba -> "/choices/0/finish_reason"
+  // Meta Llama -> "/stop_reason"
+  // Mistral AI -> "/outputs/0/stop_reason"
   @Nullable
   static String getFinishReasons(Object target) {
     String finishReason =

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -207,17 +207,225 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
     "AWSBedrockAgent"    | "GetAgent"      | "GET" | "/"                   | AWSBedrockAgentClientBuilder.standard()                             | { c -> c.getAgent(new GetAgentRequest().withAgentId("agentId")) } | ["aws.bedrock.agent.id": "agentId"] | ""
     "AWSBedrockAgent"    | "GetKnowledgeBase"      | "GET" | "/"                   | AWSBedrockAgentClientBuilder.standard()                             | { c -> c.getKnowledgeBase(new GetKnowledgeBaseRequest().withKnowledgeBaseId("knowledgeBaseId")) } | ["aws.bedrock.knowledge_base.id": "knowledgeBaseId"] | ""
     "AWSBedrockAgent"    | "GetDataSource"      | "GET" | "/"                   | AWSBedrockAgentClientBuilder.standard()                             | { c -> c.getDataSource(new GetDataSourceRequest().withDataSourceId("datasourceId").withKnowledgeBaseId("knowledgeBaseId")) } | ["aws.bedrock.data_source.id": "datasourceId"] | ""
-    "BedrockRuntime"    | "InvokeModel"      | "POST" | "/"                   | AmazonBedrockRuntimeClientBuilder.standard()                             |
-      { c -> c.invokeModel(
-        new InvokeModelRequest().withModelId("anthropic.claude-v2").withBody(StandardCharsets.UTF_8.encode(
-          "{\"prompt\":\"Hello, world!\",\"temperature\":0.7,\"top_p\":0.9,\"max_tokens_to_sample\":100}\n"
-        ))) } | ["gen_ai.request.model": "anthropic.claude-v2", "gen_ai.system": "aws_bedrock"] | """
+    "BedrockRuntime" | "InvokeModel" | "POST" | "/" |
+        AmazonBedrockRuntimeClientBuilder.standard() |
+        { c ->
+          c.invokeModel(
+              new InvokeModelRequest()
+                  .withModelId("ai21.jamba-1-5-mini-v1:0")
+                  .withBody(StandardCharsets.UTF_8.encode('''
+            {
+              "messages": [{
+                "role": "user",
+                "message": "Which LLM are you?"
+              }],
+              "max_tokens": 1000,
+              "top_p": 0.8,
+              "temperature": 0.7
+            }
+          '''))
+          )
+        } |
+        [
+            "gen_ai.request.model": "ai21.jamba-1-5-mini-v1:0",
+            "gen_ai.system": "aws_bedrock",
+            "gen_ai.request.max_tokens": "1000",
+            "gen_ai.request.temperature": "0.7",
+            "gen_ai.request.top_p": "0.8",
+            "gen_ai.response.finish_reasons": "[stop]",
+            "gen_ai.usage.input_tokens": "5",
+            "gen_ai.usage.output_tokens": "42"
+        ] |
+        '''
+    {
+      "choices": [{
+        "finish_reason": "stop"
+      }],
+      "usage": {
+        "prompt_tokens": 5,
+        "completion_tokens": 42
+      }
+    }
+    '''
+    "BedrockRuntime" | "InvokeModel" | "POST" | "/" |
+        AmazonBedrockRuntimeClientBuilder.standard() |
+        { c ->
+          c.invokeModel(
+              new InvokeModelRequest()
+                  .withModelId("amazon.titan-text-premier-v1:0")
+                  .withBody(StandardCharsets.UTF_8.encode('''
+            {
+              "inputText": "Hello, world!",
+              "textGenerationConfig": {
+                "temperature": 0.7,
+                "topP": 0.9,
+                "maxTokenCount": 100,
+                "stopSequences": ["END"]
+              }
+            }
+          '''))
+          )
+        } |
+        [
+            "gen_ai.request.model": "amazon.titan-text-premier-v1:0",
+            "gen_ai.system": "aws_bedrock",
+            "gen_ai.request.max_tokens": "100",
+            "gen_ai.request.temperature": "0.7",
+            "gen_ai.request.top_p": "0.9",
+            "gen_ai.response.finish_reasons": "[stop]",
+            "gen_ai.usage.input_tokens": "5",
+            "gen_ai.usage.output_tokens": "42"
+        ] |
+        '''
+    {
+      "inputTextTokenCount": 5,
+      "results": [
         {
-            "completion": " Here is a simple explanation of black ",
-            "stop_reason": "length",
-            "stop": "holes"
+          "tokenCount": 42,
+          "outputText": "Hi! I'm Titan, an AI assistant. How can I help you today?",
+          "completionReason": "stop"
         }
-      """
+      ]
+    }
+    '''
+    "BedrockRuntime" | "InvokeModel" | "POST" | "/" |
+        AmazonBedrockRuntimeClientBuilder.standard() |
+        { c ->
+          c.invokeModel(
+              new InvokeModelRequest()
+                  .withModelId("anthropic.claude-3-5-sonnet-20241022-v2:0")
+                  .withBody(StandardCharsets.UTF_8.encode('''
+            {
+              "anthropic_version": "bedrock-2023-05-31",
+              "messages": [{
+                "role": "user",
+                "content": "Hello, world"
+              }],
+              "max_tokens": 100,
+              "temperature": 0.7,
+              "top_p": 0.9
+            }
+          '''))
+          )
+        } |
+        [
+            "gen_ai.request.model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "gen_ai.system": "aws_bedrock",
+            "gen_ai.request.max_tokens": "100",
+            "gen_ai.request.temperature": "0.7",
+            "gen_ai.request.top_p": "0.9",
+            "gen_ai.response.finish_reasons": "[end_turn]",
+            "gen_ai.usage.input_tokens": "2095",
+            "gen_ai.usage.output_tokens": "503"
+        ] |
+        '''
+    {
+      "stop_reason": "end_turn",
+      "usage": {
+        "input_tokens": 2095,
+        "output_tokens": 503
+      }
+    }
+    '''
+    "BedrockRuntime" | "InvokeModel" | "POST" | "/" |
+        AmazonBedrockRuntimeClientBuilder.standard() |
+        { c ->
+          c.invokeModel(
+              new InvokeModelRequest()
+                  .withModelId("meta.llama3-70b-instruct-v1:0")
+                  .withBody(StandardCharsets.UTF_8.encode('''
+            {
+              "prompt": "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\\\\nDescribe the purpose of a 'hello world' program in one line. <|eot_id|>\\\\n<|start_header_id|>assistant<|end_header_id|>\\\\n",
+              "max_gen_len": 128,
+              "temperature": 0.1,
+              "top_p": 0.9
+            }
+          '''))
+          )
+        } |
+        [
+            "gen_ai.request.model": "meta.llama3-70b-instruct-v1:0",
+            "gen_ai.system": "aws_bedrock",
+            "gen_ai.request.max_tokens": "128",
+            "gen_ai.request.temperature": "0.1",
+            "gen_ai.request.top_p": "0.9",
+            "gen_ai.response.finish_reasons": "[stop]",
+            "gen_ai.usage.input_tokens": "2095",
+            "gen_ai.usage.output_tokens": "503"
+        ] |
+        '''
+    {
+      "prompt_token_count": 2095,
+      "generation_token_count": 503,
+      "stop_reason": "stop"
+    }
+    '''
+    "BedrockRuntime" | "InvokeModel" | "POST" | "/" |
+        AmazonBedrockRuntimeClientBuilder.standard() |
+        { c ->
+          c.invokeModel(
+              new InvokeModelRequest()
+                  .withModelId("cohere.command-r-v1:0")
+                  .withBody(StandardCharsets.UTF_8.encode('''
+            {
+              "message": "Convince me to write a LISP interpreter in one line.",
+              "temperature": 0.8,
+              "max_tokens": 4096,
+              "p": 0.45 
+            }
+          '''))
+          )
+        } |
+        [
+            "gen_ai.request.model": "cohere.command-r-v1:0",
+            "gen_ai.system": "aws_bedrock",
+            "gen_ai.request.max_tokens": "4096",
+            "gen_ai.request.temperature": "0.8",
+            "gen_ai.request.top_p": "0.45",
+            "gen_ai.response.finish_reasons": "[COMPLETE]",
+            "gen_ai.usage.input_tokens": "9",
+            "gen_ai.usage.output_tokens": "2"
+        ] |
+        '''
+    {
+      "text": "test-output",
+      "finish_reason": "COMPLETE"
+    }
+    '''
+    "BedrockRuntime" | "InvokeModel" | "POST" | "/" |
+        AmazonBedrockRuntimeClientBuilder.standard() |
+        { c ->
+          c.invokeModel(
+              new InvokeModelRequest()
+                  .withModelId("mistral.mistral-large-2402-v1:0")
+                  .withBody(StandardCharsets.UTF_8.encode('''
+        {
+            "prompt": "<s>[INST] Describe the difference between a compiler and interpreter in one line. [/INST]\\\\n",
+            "max_tokens": 4096,
+            "temperature": 0.75,
+            "top_p": 0.25
+        }
+    '''))
+          )
+        } |
+        [
+            "gen_ai.request.model": "mistral.mistral-large-2402-v1:0",
+            "gen_ai.system": "aws_bedrock",
+            "gen_ai.request.max_tokens": "4096",
+            "gen_ai.request.temperature": "0.75",
+            "gen_ai.request.top_p": "0.25",
+            "gen_ai.response.finish_reasons": "[stop]",
+            "gen_ai.usage.input_tokens": "16",
+            "gen_ai.usage.output_tokens": "2"
+        ] |
+        '''
+        {
+          "outputs": [{
+            "text": "test-output",
+            "stop_reason": "stop"
+          }]
+        }
+    '''
     "AWSStepFunctions" | "DescribeStateMachine" | "POST" | "/" | AWSStepFunctionsClientBuilder.standard()
     | { c -> c.describeStateMachine(new DescribeStateMachineRequest().withStateMachineArn("stateMachineArn")) }
     | ["aws.stepfunctions.state_machine.arn": "stateMachineArn"]


### PR DESCRIPTION
*Description of changes:*
Adding auto-instrumentation support for GenAI inference parameters for Java V1 AWS SDK.

The following foundational text models are supported:
- AI21 Jamba
- Amazon Titan
- Anthropic Claude
- Cohere Command R
- Meta Llama
- Mistral AI

Full list can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html). 

Note: Removed support for old Cohere Command models since they already throw a 404 response for Java V1.

New inference parameter attributes added according to OpenTelemetry Semantic Conventions for [GenAI attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#genai-attributes):
- `gen_ai.request.max_tokens`
- `gen_ai.request.temperature`
- `gen_ai.request.top_p`
- `gen_ai.response.finish_reasons`
- `gen_ai.usage.input_tokens`
- `gen_ai.usage.output_tokens`

*Test Plan:*
Set up sample app to make Bedrock Runtime `InvokeModel` API calls to the supported foundational models and verified the auto-instrumentation attributes.

`AI21 Jamba`
![ai21-jamba](https://github.com/user-attachments/assets/aa098f92-fee7-4876-b02f-eee819784c20)

`Amazon Titan`
![amazon-titan](https://github.com/user-attachments/assets/992c7f3d-873c-47ed-9d8d-5cf345f4ca68)

`Anthropic Claude`
![anthropic-claude](https://github.com/user-attachments/assets/3f147eee-03c6-49b5-a7fd-61af93b3613e)

`Cohere Command`
![cohere-command-r](https://github.com/user-attachments/assets/45d2c6be-c18c-4215-8018-b4512b7f08ae)

`Meta Llama`
![meta-llama](https://github.com/user-attachments/assets/3ce90b2f-ae18-4db9-b2a5-42b861d9f1a1)

`Mistral AI`
![mistral-ai](https://github.com/user-attachments/assets/d314f8d4-a644-43a8-9aab-4cb496e187ee)
