### PR TITLE
Set Up LLM Inference Attributes Auto-Instrumentation Java v2

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsExperimentalAttributes.java
@@ -26,6 +26,23 @@ final class AwsExperimentalAttributes {
   static final AttributeKey<String> GEN_AI_MODEL = stringKey("gen_ai.request.model");
   static final AttributeKey<String> GEN_AI_SYSTEM = stringKey("gen_ai.system");
 
+  static final AttributeKey<String> GEN_AI_REQUEST_MAX_TOKENS =
+      stringKey("gen_ai.request.max_tokens");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_TEMPERATURE =
+      stringKey("gen_ai.request.temperature");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_TOP_P = stringKey("gen_ai.request.top_p");
+
+  static final AttributeKey<String> GEN_AI_RESPONSE_FINISH_REASONS =
+      stringKey("gen_ai.response.finish_reasons");
+
+  static final AttributeKey<String> GEN_AI_USAGE_INPUT_TOKENS =
+      stringKey("gen_ai.usage.input_tokens");
+
+  static final AttributeKey<String> GEN_AI_USAGE_OUTPUT_TOKENS =
+      stringKey("gen_ai.usage.output_tokens");
+
   static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
       stringKey("aws.stepfunctions.state_machine.arn");
 
@@ -42,6 +59,15 @@ final class AwsExperimentalAttributes {
 
   static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
       stringKey("aws.lambda.resource_mapping.id");
+
+  static boolean isGenAiAttribute(String attributeKey) {
+    return attributeKey.equals(GEN_AI_REQUEST_MAX_TOKENS.getKey())
+        || attributeKey.equals(GEN_AI_REQUEST_TEMPERATURE.getKey())
+        || attributeKey.equals(GEN_AI_REQUEST_TOP_P.getKey())
+        || attributeKey.equals(GEN_AI_RESPONSE_FINISH_REASONS.getKey())
+        || attributeKey.equals(GEN_AI_USAGE_INPUT_TOKENS.getKey())
+        || attributeKey.equals(GEN_AI_USAGE_OUTPUT_TOKENS.getKey());
+  }
 
   private AwsExperimentalAttributes() {}
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -23,6 +23,12 @@ import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttrib
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.AWS_TABLE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_MODEL;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TEMPERATURE;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TOP_P;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_USAGE_INPUT_TOKENS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.AwsExperimentalAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.request;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.response;
 
@@ -51,7 +57,15 @@ enum AwsSdkRequestType {
   BEDROCKKNOWLEDGEBASEOPERATION(
       request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),
       response(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId")),
-  BEDROCKRUNTIME(request(GEN_AI_MODEL.getKey(), "modelId")),
+  BEDROCKRUNTIME(
+      request(GEN_AI_MODEL.getKey(), "modelId"),
+      request(GEN_AI_REQUEST_MAX_TOKENS.getKey(), "body"),
+      request(GEN_AI_REQUEST_TEMPERATURE.getKey(), "body"),
+      request(GEN_AI_REQUEST_TOP_P.getKey(), "body"),
+      request(GEN_AI_USAGE_INPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_RESPONSE_FINISH_REASONS.getKey(), "body"),
+      response(GEN_AI_USAGE_INPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_USAGE_OUTPUT_TOKENS.getKey(), "body")),
   STEPFUNCTION(
       request(AWS_STATE_MACHINE_ARN.getKey(), "stateMachineArn"),
       request(AWS_STEP_FUNCTIONS_ACTIVITY_ARN.getKey(), "activityArn")),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/FieldMapper.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/FieldMapper.java
@@ -65,8 +65,13 @@ class FieldMapper {
     for (int i = 1; i < path.size() && target != null; i++) {
       target = next(target, path.get(i));
     }
+    String value;
     if (target != null) {
-      String value = serializer.serialize(target);
+      if (AwsExperimentalAttributes.isGenAiAttribute(fieldMapping.getAttribute())) {
+        value = serializer.serialize(fieldMapping.getAttribute(), target);
+      } else {
+        value = serializer.serialize(target);
+      }
       if (!StringUtils.isEmpty(value)) {
         span.setAttribute(fieldMapping.getAttribute(), value);
       }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
@@ -5,13 +5,19 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -20,6 +26,8 @@ import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.StringUtils;
 
 class Serializer {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Nullable
   String serialize(Object target) {
@@ -39,6 +47,41 @@ class Serializer {
     }
     // simple type
     return target.toString();
+  }
+
+  @Nullable
+  String serialize(String attributeName, Object target) {
+    try {
+      JsonNode jsonBody;
+      if (target instanceof SdkBytes) {
+        String jsonString = ((SdkBytes) target).asUtf8String();
+        jsonBody = objectMapper.readTree(jsonString);
+      } else {
+        if (target != null) {
+          return target.toString();
+        }
+        return null;
+      }
+
+      switch (attributeName) {
+        case "gen_ai.request.max_tokens":
+          return getMaxTokens(jsonBody);
+        case "gen_ai.request.temperature":
+          return getTemperature(jsonBody);
+        case "gen_ai.request.top_p":
+          return getTopP(jsonBody);
+        case "gen_ai.response.finish_reasons":
+          return getFinishReasons(jsonBody);
+        case "gen_ai.usage.input_tokens":
+          return getInputTokens(jsonBody);
+        case "gen_ai.usage.output_tokens":
+          return getOutputTokens(jsonBody);
+        default:
+          return null;
+      }
+    } catch (JsonProcessingException e) {
+      return null;
+    }
   }
 
   @Nullable
@@ -64,5 +107,114 @@ class Serializer {
   private String serialize(Collection<?> collection) {
     String serialized = collection.stream().map(this::serialize).collect(Collectors.joining(","));
     return (StringUtils.isEmpty(serialized) ? null : "[" + serialized + "]");
+  }
+
+  @Nullable
+  private static String findFirstMatchingPath(JsonNode jsonBody, String... paths) {
+    if (jsonBody == null) {
+      return null;
+    }
+
+    return Stream.of(paths)
+        .map(
+            path -> {
+              JsonNode node = jsonBody.at(path);
+              if (node != null && !node.isMissingNode()) {
+                return node.asText();
+              }
+              return null;
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Nullable
+  private static String approximateTokenCount(JsonNode jsonBody, String... textPaths) {
+    if (jsonBody == null) {
+      return null;
+    }
+
+    return Stream.of(textPaths)
+        .map(
+            path -> {
+              JsonNode node = jsonBody.at(path);
+              if (node != null && !node.isMissingNode()) {
+                int tokenEstimate = (int) Math.ceil(node.asText().length() / 6.0);
+                return Integer.toString(tokenEstimate);
+              }
+              return null;
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Nullable
+  private static String getMaxTokens(JsonNode jsonBody) {
+    return findFirstMatchingPath(
+        jsonBody, "/textGenerationConfig/maxTokenCount", "/max_tokens", "/max_gen_len");
+  }
+
+  @Nullable
+  private static String getTemperature(JsonNode jsonBody) {
+    return findFirstMatchingPath(jsonBody, "/textGenerationConfig/temperature", "/temperature");
+  }
+
+  @Nullable
+  private static String getTopP(JsonNode jsonBody) {
+    return findFirstMatchingPath(jsonBody, "/textGenerationConfig/topP", "/top_p", "/p");
+  }
+
+  @Nullable
+  private static String getFinishReasons(JsonNode jsonBody) {
+    String finishReason = findFirstMatchingPath(
+        jsonBody,
+        "/results/0/completionReason",
+        "/stop_reason",
+        "/generations/0/finish_reason",
+        "/choices/0/finish_reason",
+        "/outputs/0/stop_reason",
+        "/finish_reason");
+
+    return finishReason != null ? "[" + finishReason + "]" : null;
+  }
+
+  @Nullable
+  private static String getInputTokens(JsonNode jsonBody) {
+    // Try direct tokens counts first
+    String directCount =
+        findFirstMatchingPath(
+            jsonBody,
+            "/inputTextTokenCount",
+            "/usage/input_tokens",
+            "/usage/prompt_tokens",
+            "/prompt_token_count");
+
+    if (directCount != null) {
+      return directCount;
+    }
+
+    // Fall back to token approximation
+    return approximateTokenCount(jsonBody, "/prompt", "/message");
+  }
+
+  @Nullable
+  private static String getOutputTokens(JsonNode jsonBody) {
+    // Try direct token counts first
+    String directCount =
+        findFirstMatchingPath(
+            jsonBody,
+            "/results/0/tokenCount",
+            "/usage/output_tokens",
+            "/usage/completion_tokens",
+            "/generation_token_count");
+
+    if (directCount != null) {
+      return directCount;
+    }
+
+    // Fall back to token approximation
+    return approximateTokenCount(jsonBody, "/outputs/0/text", "/text");
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/Serializer.java
@@ -150,36 +150,77 @@ class Serializer {
         .orElse(null);
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
+  // Anthropic Claude -> "/max_tokens"
+  // Cohere Command -> "/max_tokens"
+  // Cohere Command R -> "/max_tokens"
+  // AI21 Jamba -> "/max_tokens"
+  // Meta Llama -> "/max_gen_len"
+  // Mistral AI -> "/max_tokens"
   @Nullable
   private static String getMaxTokens(JsonNode jsonBody) {
     return findFirstMatchingPath(
         jsonBody, "/textGenerationConfig/maxTokenCount", "/max_tokens", "/max_gen_len");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/textGenerationConfig/temperature"
+  // Anthropic Claude -> "/temperature"
+  // Cohere Command -> "/temperature"
+  // Cohere Command R -> "/temperature"
+  // AI21 Jamba -> "/temperature"
+  // Meta Llama -> "/temperature"
+  // Mistral AI -> "/temperature"
   @Nullable
   private static String getTemperature(JsonNode jsonBody) {
     return findFirstMatchingPath(jsonBody, "/textGenerationConfig/temperature", "/temperature");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/textGenerationConfig/topP"
+  // Anthropic Claude -> "/top_p"
+  // Cohere Command -> "/p"
+  // Cohere Command R -> "/p"
+  // AI21 Jamba -> "/top_p"
+  // Meta Llama -> "/top_p"
+  // Mistral AI -> "/top_p"
   @Nullable
   private static String getTopP(JsonNode jsonBody) {
     return findFirstMatchingPath(jsonBody, "/textGenerationConfig/topP", "/top_p", "/p");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/results/0/completionReason"
+  // Anthropic Claude -> "/stop_reason"
+  // Cohere Command -> "/generations/0/finish_reason"
+  // Cohere Command R -> "/finish_reason"
+  // AI21 Jamba -> "/choices/0/finish_reason"
+  // Meta Llama -> "/stop_reason"
+  // Mistral AI -> "/outputs/0/stop_reason"
   @Nullable
   private static String getFinishReasons(JsonNode jsonBody) {
-    String finishReason = findFirstMatchingPath(
-        jsonBody,
-        "/results/0/completionReason",
-        "/stop_reason",
-        "/generations/0/finish_reason",
-        "/choices/0/finish_reason",
-        "/outputs/0/stop_reason",
-        "/finish_reason");
+    String finishReason =
+        findFirstMatchingPath(
+            jsonBody,
+            "/results/0/completionReason",
+            "/stop_reason",
+            "/generations/0/finish_reason",
+            "/choices/0/finish_reason",
+            "/outputs/0/stop_reason",
+            "/finish_reason");
 
     return finishReason != null ? "[" + finishReason + "]" : null;
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/inputTextTokenCount"
+  // Anthropic Claude -> "/usage/input_tokens"
+  // Cohere Command -> "/prompt"
+  // Cohere Command R -> "/message"
+  // AI21 Jamba -> "/usage/prompt_tokens"
+  // Meta Llama -> "/prompt_token_count"
+  // Mistral AI -> "/prompt"
   @Nullable
   private static String getInputTokens(JsonNode jsonBody) {
     // Try direct tokens counts first
@@ -199,6 +240,14 @@ class Serializer {
     return approximateTokenCount(jsonBody, "/prompt", "/message");
   }
 
+  // Model -> Path Mapping:
+  // Amazon Titan -> "/results/0/tokenCount"
+  // Anthropic Claude -> "/usage/output_tokens"
+  // Cohere Command -> "/generations/0/text"
+  // Cohere Command R -> "/text"
+  // AI21 Jamba -> "/usage/completion_tokens"
+  // Meta Llama -> "/generation_token_count"
+  // Mistral AI -> "/outputs/0/text"
   @Nullable
   private static String getOutputTokens(JsonNode jsonBody) {
     // Try direct token counts first


### PR DESCRIPTION
*Description of changes:*
Adding auto-instrumentation support for GenAI inference parameters for Java V2 AWS SDK.

The following foundational text models are supported:
- AI21 Jamba
- Amazon Titan
- Anthropic Claude
- Cohere Command
- Cohere Command R
- Meta Llama
- Mistral AI

Full list can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html). Note, we do not support Stability AI models at this time since they are focused on text to image

Note: Removed support for old Cohere Command models since they already throw a 404 response for Java V2.

New inference parameter attributes added according to OpenTelemetry Semantic Conventions for [GenAI attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#genai-attributes):
- `gen_ai.request.max_tokens`
- `gen_ai.request.temperature`
- `gen_ai.request.top_p`
- `gen_ai.response.finish_reasons`
- `gen_ai.usage.input_tokens`
- `gen_ai.usage.output_tokens`

*Test Plan:*
Set up sample app to make Bedrock Runtime `InvokeModel` API calls to the supported foundational models and verified the auto-instrumentation attributes.

`AI21 Jamba`
<img width="2560" alt="ai21-jamba" src="https://github.com/user-attachments/assets/d737f396-9dad-480c-b0af-25490dda33a2">

`Amazon Titan`
<img width="2560" alt="amazon-titan" src="https://github.com/user-attachments/assets/be2e7eaf-4dfb-417b-a90b-484f3c23e44a">

`Anthropic Claude`
<img width="2560" alt="anthropic-claude" src="https://github.com/user-attachments/assets/458d6e3a-4c64-44cc-aabc-1cba50dcd685">

`Cohere Command R`
![cohere-command-r](https://github.com/user-attachments/assets/641324d3-0d33-457a-8218-58987d0abf61)

`Meta Llama`
<img width="2560" alt="meta-llama" src="https://github.com/user-attachments/assets/752f9dd5-d877-4179-8c67-eddecff687d8">

`Mistral AI`
<img width="2560" alt="mistral-ai" src="https://github.com/user-attachments/assets/55f1fff5-5cea-49bc-bcd0-d1f3a15518f2">