### PR TITLE
Apply bug fixes to JMX Metric library

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
+++ b/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 
 /** An {@link AgentListener} that enables JMX metrics during agent startup. */
@@ -32,22 +33,22 @@ public class JmxMetricInsightInstaller implements AgentListener {
 
     if (config.getBoolean("otel.jmx.enabled", true)) {
       JmxMetricInsight service =
-          JmxMetricInsight.createService(GlobalOpenTelemetry.get(), beanDiscoveryDelay(config));
+          JmxMetricInsight.createService(
+              GlobalOpenTelemetry.get(), beanDiscoveryDelay(config).toMillis());
       MetricConfiguration conf = buildMetricConfiguration(config);
       service.start(conf);
     }
   }
 
-  private static long beanDiscoveryDelay(ConfigProperties configProperties) {
-    Long discoveryDelay = configProperties.getLong("otel.jmx.discovery.delay");
+  private static Duration beanDiscoveryDelay(ConfigProperties configProperties) {
+    Duration discoveryDelay = configProperties.getDuration("otel.jmx.discovery.delay");
     if (discoveryDelay != null) {
       return discoveryDelay;
     }
 
     // If discovery delay has not been configured, have a peek at the metric export interval.
     // It makes sense for both of these values to be similar.
-    long exportInterval = configProperties.getLong("otel.metric.export.interval", 60000);
-    return exportInterval;
+    return configProperties.getDuration("otel.metric.export.interval", Duration.ofMinutes(1));
   }
 
   private static String resourceFor(String platform) {

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
@@ -39,12 +39,18 @@ class BeanFinder {
   void discoverBeans(MetricConfiguration conf) {
     this.conf = conf;
 
-    if (!conf.isEmpty()) {
-      // Issue 9336: Corner case: PlatformMBeanServer will remain unitialized until a direct
-      // reference to it is made. This call makes sure that the PlatformMBeanServer will be in
-      // the set of MBeanServers reported by MBeanServerFactory.
-      ManagementFactory.getPlatformMBeanServer();
-    }
+    exec.schedule(
+        () -> {
+          // Issue 9336: Corner case: PlatformMBeanServer will remain unitialized until a direct
+          // reference to it is made. This call makes sure that the PlatformMBeanServer will be in
+          // the set of MBeanServers reported by MBeanServerFactory.
+          // Issue 11143: This call initializes java.util.logging.LogManager. We should not call it
+          // before application has had a chance to configure custom log manager. This is needed for
+          // wildfly.
+          ManagementFactory.getPlatformMBeanServer();
+        },
+        discoveryDelay,
+        TimeUnit.MILLISECONDS);
 
     exec.schedule(
         new Runnable() {

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
@@ -25,7 +25,13 @@ class BeanFinder {
 
   private final MetricRegistrar registrar;
   private MetricConfiguration conf;
-  private final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService exec =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            Thread result = new Thread(runnable, "jmx_bean_finder");
+            result.setDaemon(true);
+            return result;
+          });
   private final long discoveryDelay;
   private final long maxDelay;
   private long delay = 1000; // number of milliseconds until first attempt to discover MBeans


### PR DESCRIPTION
From 2.4.0
Fix jmx-metrics on WildFly (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11151)
Use daemon thread for scheduling in jmx-metrics BeanFinder (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11337)