### PR TITLE
Fix Muzzle check for AWS SDK v1 & v2 checks

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInstrumentationModule.java
@@ -20,7 +20,7 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
 
   @Override
   public boolean isHelperClass(String className) {
-    return className.startsWith("io.opentelemetry.contrib.awsxray.");
+    return className.startsWith("io.opentelemetry.contrib.awsxray.") || className.startsWith("com.fasterxml.jackson");
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AbstractAwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AbstractAwsSdkInstrumentationModule.java
@@ -24,7 +24,7 @@ abstract class AbstractAwsSdkInstrumentationModule extends InstrumentationModule
 
   @Override
   public boolean isHelperClass(String className) {
-    return className.startsWith("io.opentelemetry.contrib.awsxray.");
+    return className.startsWith("io.opentelemetry.contrib.awsxray.") || className.startsWith("com.fasterxml.jackson");
   }
 
   @Override


### PR DESCRIPTION
Add com.fasterxml.jackson.* as helper classes in AWS SDK V1 & V2 instrumentation to fix Muzzle check in the edge cases