### PR TITLE
update genai system attribute name to align with upstream

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
@@ -145,7 +145,7 @@ class AwsSdkExperimentalAttributesExtractor
         if (!Objects.equals(requestClassName, "InvokeModelRequest")) {
           break;
         }
-        attributes.put(AWS_BEDROCK_SYSTEM, "aws_bedrock");
+        attributes.put(AWS_BEDROCK_SYSTEM, "aws.bedrock");
         Function<Object, String> getter = RequestAccess::getModelId;
         String modelId = getter.apply(originalRequest);
         attributes.put(AWS_BEDROCK_RUNTIME_MODEL_ID, modelId);

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -228,7 +228,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
       } |
       [
         "gen_ai.request.model": "ai21.jamba-1-5-mini-v1:0",
-        "gen_ai.system": "aws_bedrock",
+        "gen_ai.system": "aws.bedrock",
         "gen_ai.request.max_tokens": "1000",
         "gen_ai.request.temperature": "0.7",
         "gen_ai.request.top_p": "0.8",
@@ -268,7 +268,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
       } |
       [
         "gen_ai.request.model": "amazon.titan-text-premier-v1:0",
-        "gen_ai.system": "aws_bedrock",
+        "gen_ai.system": "aws.bedrock",
         "gen_ai.request.max_tokens": "100",
         "gen_ai.request.temperature": "0.7",
         "gen_ai.request.top_p": "0.9",
@@ -310,7 +310,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
       } |
       [
         "gen_ai.request.model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-        "gen_ai.system": "aws_bedrock",
+        "gen_ai.system": "aws.bedrock",
         "gen_ai.request.max_tokens": "100",
         "gen_ai.request.temperature": "0.7",
         "gen_ai.request.top_p": "0.9",
@@ -345,7 +345,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
       } |
       [
         "gen_ai.request.model": "meta.llama3-70b-instruct-v1:0",
-        "gen_ai.system": "aws_bedrock",
+        "gen_ai.system": "aws.bedrock",
         "gen_ai.request.max_tokens": "128",
         "gen_ai.request.temperature": "0.1",
         "gen_ai.request.top_p": "0.9",
@@ -378,7 +378,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
       } |
       [
         "gen_ai.request.model": "cohere.command-r-v1:0",
-        "gen_ai.system": "aws_bedrock",
+        "gen_ai.system": "aws.bedrock",
         "gen_ai.request.max_tokens": "4096",
         "gen_ai.request.temperature": "0.8",
         "gen_ai.request.top_p": "0.45",
@@ -410,7 +410,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
       } |
       [
         "gen_ai.request.model": "mistral.mistral-large-2402-v1:0",
-        "gen_ai.system": "aws_bedrock",
+        "gen_ai.system": "aws.bedrock",
         "gen_ai.request.max_tokens": "4096",
         "gen_ai.request.temperature": "0.75",
         "gen_ai.request.top_p": "0.25",

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 
 /** AWS request execution interceptor. */
 final class TracingExecutionInterceptor implements ExecutionInterceptor {
-  private static final String GEN_AI_SYSTEM_BEDROCK = "aws_bedrock";
+  private static final String GEN_AI_SYSTEM_BEDROCK = "aws.bedrock";
 
   // the class name is part of the attribute name, so that it will be shaded when used in javaagent
   // instrumentation, and won't conflict with usage outside javaagent instrumentation

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -164,7 +164,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
               "aws.bedrock.data_source.id" "datasourceId"
             } else if (service == "BedrockRuntime" && operation == "InvokeModel") {
               "gen_ai.request.model" "meta.llama2-13b-chat-v1"
-              "gen_ai.system" "aws_bedrock"
+              "gen_ai.system" "aws.bedrock"
             } else if (service == "Sfn" && operation == "DescribeStateMachine") {
               "aws.stepfunctions.state_machine.arn" "stateMachineArn"
             } else if (service == "Sfn" && operation == "DescribeActivity") {


### PR DESCRIPTION
*Description of changes:*
Updating `gen_ai.system` attribute key to better align with upstream Otel conventions.

Context: https://github.com/open-telemetry/semantic-conventions/pull/1574#issuecomment-2539951918

*Test plan:*
Ran updated unit tests and new attribute value in spans from sample apps.
<img width="2560" alt="Screenshot 2024-12-16 at 3 40 35 PM" src="https://github.com/user-attachments/assets/d087921a-aca0-4bf9-b657-9e57bee2eea2" />
<img width="2560" alt="Screenshot 2024-12-16 at 3 39 26 PM" src="https://github.com/user-attachments/assets/6087c192-98be-4345-a90c-5216023600ae" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.